### PR TITLE
increased vanq hammer prio and HOW prio in ashen

### DIFF
--- a/engine/action/sc_action.cpp
+++ b/engine/action/sc_action.cpp
@@ -3664,7 +3664,7 @@ std::unique_ptr<expr_t> action_t::create_expression( util::string_view name_str 
         struct in_flight_multi_expr_t : public expr_t
         {
           const std::vector<action_t*> action_list;
-          in_flight_multi_expr_t( const std::vector<action_t*> al ) : expr_t( "in_flight" ), action_list( std::move( al ) )
+          in_flight_multi_expr_t( std::vector<action_t*> al ) : expr_t( "in_flight" ), action_list( std::move( al ) )
           {
           }
           double evaluate() override

--- a/engine/action/sc_action.cpp
+++ b/engine/action/sc_action.cpp
@@ -3210,7 +3210,7 @@ std::unique_ptr<expr_t> action_t::create_expression( util::string_view name_str 
     struct last_used_expr_t : public expr_t
     {
       const std::vector<action_t*> action_list;
-      last_used_expr_t( std::vector<action_t*>&& al ) : expr_t( "last_used" ), action_list( al )
+      last_used_expr_t( std::vector<action_t*> al ) : expr_t( "last_used" ), action_list( std::move( al ) )
       {
       }
       double evaluate() override
@@ -3664,7 +3664,7 @@ std::unique_ptr<expr_t> action_t::create_expression( util::string_view name_str 
         struct in_flight_multi_expr_t : public expr_t
         {
           const std::vector<action_t*> action_list;
-          in_flight_multi_expr_t( const std::vector<action_t*>&& al ) : expr_t( "in_flight" ), action_list( al )
+          in_flight_multi_expr_t( const std::vector<action_t*> al ) : expr_t( "in_flight" ), action_list( std::move( al ) )
           {
           }
           double evaluate() override
@@ -3682,8 +3682,8 @@ std::unique_ptr<expr_t> action_t::create_expression( util::string_view name_str 
           const std::vector<action_t*> action_list;
           action_t& action;
 
-          in_flight_to_target_multi_expr_t( const std::vector<action_t*>&& al, action_t& a )
-            : expr_t( "in_flight_to_target" ), action_list( al ), action( a )
+          in_flight_to_target_multi_expr_t( std::vector<action_t*> al, action_t& a )
+            : expr_t( "in_flight_to_target" ), action_list( std::move( al ) ), action( a )
           {
           }
           double evaluate() override
@@ -3704,9 +3704,9 @@ std::unique_ptr<expr_t> action_t::create_expression( util::string_view name_str 
         struct in_flight_remains_multi_expr_t : public expr_t
         {
           const std::vector<action_t*> action_list;
-          in_flight_remains_multi_expr_t( const std::vector<action_t*>&& al ) :
+          in_flight_remains_multi_expr_t( std::vector<action_t*> al ) :
             expr_t( "in_flight" ),
-            action_list( al )
+            action_list( std::move( al ) )
           { }
 
           double evaluate() override

--- a/engine/class_modules/monk/sc_monk_pets.cpp
+++ b/engine/class_modules/monk/sc_monk_pets.cpp
@@ -1632,7 +1632,14 @@ public:
     {
       background              = true;
       merge_report            = false;
-      aoe                     = (int)o()->passives.fallen_monk_fists_of_fury->effectN( 1 ).base_value() + ( o()->bugs ? 0 : 1 );
+      if ( p->o()->bugs )
+        aoe = 1 + o()->passives.fallen_monk_fists_of_fury->effectN( 1 ).base_value();
+      else
+      {
+        aoe                 = -1;
+        reduced_aoe_targets = o()->passives.fallen_monk_fists_of_fury->effectN( 1 ).base_value();
+        full_amount_targets = 1;
+      }
       attack_power_mod.direct = o()->passives.fallen_monk_fists_of_fury->effectN( 5 ).ap_coeff();
       ap_type                 = attack_power_type::WEAPON_BOTH;
       dot_duration            = timespan_t::zero();
@@ -1737,8 +1744,13 @@ public:
     {
       dual = background    = true;
       merge_report         = false;
-      aoe                 = -1;
-      reduced_aoe_targets = p->o()->spec.spinning_crane_kick->effectN( 1 ).base_value();
+      if ( p->o()->bugs )
+        aoe = p->o()->passives.fallen_monk_spinning_crane_kick->effectN( 1 ).base_value();
+      else
+      {
+        aoe                 = -1;
+        reduced_aoe_targets = p->o()->passives.fallen_monk_spinning_crane_kick->effectN( 1 ).base_value();
+      }
       trigger_mystic_touch = true;
 
       // Reset some variables to ensure proper execution
@@ -2232,7 +2244,15 @@ public:
     {
       background   = true;
       merge_report = false;
-      aoe          = (int)o()->passives.fallen_monk_fists_of_fury->effectN( 1 ).base_value() + ( o()->bugs ? 0 : 1 );
+      if ( p->o()->bugs )
+        aoe = 1 + o()->passives.fallen_monk_fists_of_fury->effectN( 1 ).base_value();
+      else
+      {
+        aoe                 = -1;
+        reduced_aoe_targets = o()->passives.fallen_monk_fists_of_fury->effectN( 1 ).base_value();
+        full_amount_targets = 1;
+      }
+
       attack_power_mod.direct = o()->passives.fallen_monk_fists_of_fury->effectN( 5 ).ap_coeff();
       ap_type                 = attack_power_type::WEAPON_BOTH;
       dot_duration            = timespan_t::zero();
@@ -2335,8 +2355,13 @@ public:
     {
       dual = background    = true;
       merge_report         = false;
-      aoe                  = -1;
-      reduced_aoe_targets  = p->o()->spec.spinning_crane_kick->effectN( 1 ).base_value();
+      if ( p->o()->bugs )
+        aoe = p->o()->passives.fallen_monk_spinning_crane_kick->effectN( 1 ).base_value();
+      else
+      {
+        aoe                 = -1;
+        reduced_aoe_targets = p->o()->passives.fallen_monk_spinning_crane_kick->effectN( 1 ).base_value();
+      }
       trigger_mystic_touch = true;
 
       // Reset some variables to ensure proper execution

--- a/engine/class_modules/monk/sc_monk_pets.cpp
+++ b/engine/class_modules/monk/sc_monk_pets.cpp
@@ -1706,7 +1706,11 @@ public:
 
       trigger_mystic_touch = true;
 
-      cooldown->duration = timespan_t::from_seconds( 2 );
+      if ( p->o()->specialization() == MONK_WINDWALKER )
+        cooldown->duration = timespan_t::from_seconds( 2 );
+      else
+        // Only want to cast this at most 2 times during a 6 second summon.
+        cooldown->duration = timespan_t::from_seconds( 3 );
       trigger_gcd = timespan_t::from_seconds( 1.5 );
 
       cooldown->hasted = false;
@@ -1768,7 +1772,11 @@ public:
 
       tick_action = new tiger_adept_spinning_crane_kick_tick_t( p );
 
-      cooldown->duration = timespan_t::from_seconds( 2 );
+      if ( p->o()->specialization() == MONK_WINDWALKER )
+        cooldown->duration = timespan_t::from_seconds( 2 );
+      else
+        // Only want to cast this at most 1 time during a 6 second summon.
+        cooldown->duration = timespan_t::from_seconds( 6 );
       trigger_gcd        = timespan_t::from_seconds( 1.5 );
     }
 

--- a/engine/class_modules/sc_druid.cpp
+++ b/engine/class_modules/sc_druid.cpp
@@ -8139,7 +8139,13 @@ void druid_t::init_base_stats()
 {
   // Set base distance based on spec
   if ( base.distance < 1 )
-    base.distance = ( specialization() == DRUID_FERAL || specialization() == DRUID_GUARDIAN ) ? 5 : 30;
+  {
+    if ( specialization() == DRUID_FERAL || specialization() == DRUID_GUARDIAN ||
+         ( specialization() == DRUID_RESTORATION && talent.feral_affinity->ok() ) )
+      base.distance = 5;
+    else
+      base.distance = 30;
+  }
 
   player_t::init_base_stats();
 

--- a/engine/class_modules/sc_rogue.cpp
+++ b/engine/class_modules/sc_rogue.cpp
@@ -5238,12 +5238,6 @@ struct vanish_t : public stealth_like_buff_t<buff_t>
         r->cooldowns.marked_for_death, r->cooldowns.riposte, r->cooldowns.roll_the_bones, r->cooldowns.secret_technique,
         r->cooldowns.sepsis, r->cooldowns.serrated_bone_spike, r->cooldowns.shadow_blades, r->cooldowns.shadow_dance,
         r->cooldowns.shiv, r->cooldowns.sprint, r->cooldowns.symbols_of_death, r->cooldowns.vendetta };
-
-      // 11/06/2021 -- CDR is applied twice to Dreadblades: https://github.com/SimCMinMax/WoW-BugTracker/issues/821
-      if ( r->bugs )
-      {
-        shadowdust_cooldowns.push_back( r->cooldowns.dreadblades );
-      }
     }
   }
 

--- a/engine/player/azerite_data.cpp
+++ b/engine/player/azerite_data.cpp
@@ -1621,8 +1621,8 @@ void elemental_whirl( special_effect_t& effect )
     std::vector<buff_t*> buffs;
 
     public:
-    ew_proc_cb_t( const special_effect_t& effect, const std::vector<buff_t*>&& b ) :
-      dbc_proc_callback_t( effect.player, effect ), buffs( b )
+    ew_proc_cb_t( const special_effect_t& effect, std::vector<buff_t*> b ) :
+      dbc_proc_callback_t( effect.player, effect ), buffs( std::move( b ) )
     { }
 
     void execute( action_t* /* a */, action_state_t* /* state */ ) override
@@ -2739,8 +2739,8 @@ void secrets_of_the_deep( special_effect_t& effect )
   {
     std::vector<buff_t*> buffs;
 
-    sotd_cb_t( const special_effect_t& effect, const std::vector<buff_t*>&& b ) :
-      dbc_proc_callback_t( effect.player, effect ), buffs( b )
+    sotd_cb_t( const special_effect_t& effect, std::vector<buff_t*> b ) :
+      dbc_proc_callback_t( effect.player, effect ), buffs( std::move( b ) )
     { }
 
     void execute( action_t*, action_state_t* ) override
@@ -2777,8 +2777,8 @@ void combined_might( special_effect_t& effect )
   {
     std::vector<buff_t*> buffs;
 
-    combined_might_cb_t( const special_effect_t& effect, const std::vector<buff_t*>&& b ) :
-      dbc_proc_callback_t( effect.player, effect ), buffs( b )
+    combined_might_cb_t( const special_effect_t& effect, std::vector<buff_t*> b ) :
+      dbc_proc_callback_t( effect.player, effect ), buffs( std::move( b ) )
     { }
 
     void execute( action_t*, action_state_t* ) override
@@ -2851,8 +2851,8 @@ void relational_normalization_gizmo( special_effect_t& effect )
   {
     std::vector<buff_t*> buffs;
 
-    gizmo_cb_t( const special_effect_t& effect, const std::vector<buff_t*>&& b ) :
-      dbc_proc_callback_t( effect.player, effect ), buffs( b )
+    gizmo_cb_t( const special_effect_t& effect, std::vector<buff_t*> b ) :
+      dbc_proc_callback_t( effect.player, effect ), buffs( std::move( b ) )
     { }
 
     // TODO: Probability distribution?

--- a/engine/player/sc_player.cpp
+++ b/engine/player/sc_player.cpp
@@ -5645,9 +5645,10 @@ void player_t::arise()
 
   // Requires index-based lookup since on-arise callbacks may
   // insert new on-arise callbacks to the vector.
-  for ( const auto& cb : callbacks_on_arise )
+  for ( size_t i = 0; i < callbacks_on_arise.size(); ++i ) // NOLINT(modernize-loop-convert)
   {
-     // If the callback comes from a different actor, execute it only
+    auto& cb = callbacks_on_arise[ i ];
+    // If the callback comes from a different actor, execute it only
     // if that actor is active.
     if ( this == cb.first || cb.first->is_active() )
       cb.second();

--- a/engine/player/sc_unique_gear.cpp
+++ b/engine/player/sc_unique_gear.cpp
@@ -12,6 +12,7 @@
 #include "player/soulbinds.hpp"
 #include "simulationcraft.hpp"
 #include "dbc/racial_spells.hpp"
+#include "util/util.hpp"
 #include <cctype>
 #include <memory>
 
@@ -3692,8 +3693,7 @@ void unique_gear::initialize_special_effect( special_effect_t& effect,
     if ( ! dbitem -> encoded_options.empty() )
     {
       std::string encoded_options = dbitem -> encoded_options;
-      for ( char encoded_option : encoded_options )
-        encoded_option = std::tolower( encoded_option );
+      util::tolower( encoded_options );
       // Note, if the encoding parse fails (this should never ever happen),
       // we don't parse game client data either.
       special_effect::parse_special_effect_encoding( effect, encoded_options );

--- a/engine/player/unique_gear_bfa.cpp
+++ b/engine/player/unique_gear_bfa.cpp
@@ -784,8 +784,8 @@ void items::incessantly_ticking_clock( special_effect_t& effect )
     std::vector<buff_t*> buffs;
     size_t state;
 
-    clock_cb_t( const special_effect_t& effect, const std::vector<buff_t*>&& b )
-      : dbc_proc_callback_t( effect.player, effect ), buffs( b ), state( 0U )
+    clock_cb_t( const special_effect_t& effect, std::vector<buff_t*> b )
+      : dbc_proc_callback_t( effect.player, effect ), buffs( std::move( b ) ), state( 0U )
     {
     }
 
@@ -1327,8 +1327,8 @@ void items::harlans_loaded_dice( special_effect_t& effect )
   {
     std::vector<std::vector<buff_t*>> buffs;
 
-    harlans_cb_t( const special_effect_t& effect, const std::vector<std::vector<buff_t*>>&& b )
-      : dbc_proc_callback_t( effect.item, effect ), buffs( b )
+    harlans_cb_t( const special_effect_t& effect, std::vector<std::vector<buff_t*>> b )
+      : dbc_proc_callback_t( effect.item, effect ), buffs( std::move( b ) )
     {
     }
 

--- a/engine/player/unique_gear_legion.cpp
+++ b/engine/player/unique_gear_legion.cpp
@@ -1660,8 +1660,8 @@ struct injector_proc_cb_t : public dbc_proc_callback_t
   stat_buff_t* large_buff;
 
   injector_proc_cb_t( const special_effect_t& effect,
-    const std::vector<stat_buff_t*>&& small_buffs_, stat_buff_t* large_buff_ ) :
-    dbc_proc_callback_t( effect.item, effect ), small_buffs( small_buffs_ ), large_buff( large_buff_ )
+    std::vector<stat_buff_t*> small_buffs_, stat_buff_t* large_buff_ ) :
+    dbc_proc_callback_t( effect.item, effect ), small_buffs( std::move( small_buffs_ ) ), large_buff( large_buff_ )
   { }
 
   void execute( action_t* /* a */, action_state_t* /* state */ ) override
@@ -3276,8 +3276,8 @@ struct dreadstone_proc_cb_t : public dbc_proc_callback_t
 {
   const std::vector<stat_buff_t*> buffs;
 
-  dreadstone_proc_cb_t( const special_effect_t& effect, const std::vector<stat_buff_t*>&& buffs_ ) :
-    dbc_proc_callback_t( effect.item, effect ), buffs( buffs_ )
+  dreadstone_proc_cb_t( const special_effect_t& effect, std::vector<stat_buff_t*> buffs_ ) :
+    dbc_proc_callback_t( effect.item, effect ), buffs( std::move( buffs_ ) )
   { }
 
   void execute( action_t* /* a */, action_state_t* /* state */ ) override

--- a/engine/player/unique_gear_shadowlands.cpp
+++ b/engine/player/unique_gear_shadowlands.cpp
@@ -343,8 +343,8 @@ struct SL_darkmoon_deck_t : public darkmoon_deck_t
   std::vector<const spell_data_t*> cards;
   const spell_data_t* top;
 
-  SL_darkmoon_deck_t( const special_effect_t& e, const std::vector<unsigned>&& c )
-    : darkmoon_deck_t( e ), card_ids( c ), top( spell_data_t::nil() )
+  SL_darkmoon_deck_t( const special_effect_t& e, std::vector<unsigned> c )
+    : darkmoon_deck_t( e ), card_ids( std::move( c ) ), top( spell_data_t::nil() )
   {}
 
   void initialize() override

--- a/profiles/T27_Raid.simc
+++ b/profiles/T27_Raid.simc
@@ -31,6 +31,7 @@ T27_Monk_Brewmaster.simc
 T27_Monk_Windwalker.simc
 T27_Monk_Windwalker_Necrolord.simc
 # T27_Monk_Windwalker_Night_Fae.simc
+# T27_Monk_Windwalker_Venthyr.simc
 # T27_Monk_Windwalker_Serenity.simc
 
 T27_Paladin_Protection.simc

--- a/profiles/Tier27/T27_Monk_Windwalker_Venthyr.simc
+++ b/profiles/Tier27/T27_Monk_Windwalker_Venthyr.simc
@@ -1,0 +1,200 @@
+monk="T27_Monk_Windwalker_Venthyr"
+source=default
+spec=windwalker
+level=60
+race=mechagnome
+role=dps
+position=back
+talents=2020012
+covenant=venthyr
+soulbind=theotar_the_mad_duke:9,soothing_shade/Imbued_reflections:9:1/coordinated_offensive:9:1/token_of_appreciation/xuens_bond:9:1/its_always_tea_time/party_favors
+renown=80
+
+# Default consumables
+potion=potion_of_spectral_agility
+flask=spectral_flask_of_power
+food=feast_of_gluttonous_hedonism
+augmentation=veiled
+temporary_enchant=main_hand:shaded_weightstone/off_hand:shaded_weightstone
+
+# This default action priority list is automatically created based on your character.
+# It is a attempt to provide you with a action list that is both simple and practicable,
+# while resulting in a meaningful and good simulation. It may not result in the absolutely highest possible dps.
+# Feel free to edit, adapt and improve it to your own needs.
+# SimulationCraft is always looking for updates and improvements to the default action lists.
+
+# Executed before combat begins. Accepts non-harmful actions only.
+actions.precombat=flask
+actions.precombat+=/food
+actions.precombat+=/augmentation
+# Snapshot raid buffed stats before combat begins and pre-potting is done.
+actions.precombat+=/snapshot_stats
+actions.precombat+=/variable,name=xuen_on_use_trinket,op=set,value=equipped.inscrutable_quantum_device|equipped.gladiators_badge|equipped.wrathstone|equipped.overcharged_anima_battery|equipped.shadowgrasp_totem
+actions.precombat+=/fleshcraft
+actions.precombat+=/chi_burst
+actions.precombat+=/chi_wave,if=!talent.energizing_elixir.enabled
+
+# Executed every time the actor is available.
+actions=auto_attack
+actions+=/spear_hand_strike,if=target.debuff.casting.react
+actions+=/variable,name=hold_xuen,op=set,value=cooldown.invoke_xuen_the_white_tiger.remains>fight_remains|fight_remains-cooldown.invoke_xuen_the_white_tiger.remains<120&((talent.serenity&fight_remains>cooldown.serenity.remains&cooldown.serenity.remains>10)|(cooldown.storm_earth_and_fire.full_recharge_time<fight_remains&cooldown.storm_earth_and_fire.full_recharge_time>15)|(cooldown.storm_earth_and_fire.charges=0&cooldown.storm_earth_and_fire.remains<fight_remains))
+actions+=/potion,if=(buff.serenity.up|buff.storm_earth_and_fire.up)&pet.xuen_the_white_tiger.active|fight_remains<=60
+actions+=/call_action_list,name=serenity,if=buff.serenity.up
+actions+=/call_action_list,name=weapons_of_order,if=buff.weapons_of_order.up
+actions+=/call_action_list,name=opener,if=time<4&chi<5&!pet.xuen_the_white_tiger.active
+actions+=/fist_of_the_white_tiger,target_if=min:debuff.mark_of_the_crane.remains,if=chi.max-chi>=3&(energy.time_to_max<1|energy.time_to_max<4&cooldown.fists_of_fury.remains<1.5|cooldown.weapons_of_order.remains<2)&!debuff.bonedust_brew_debuff.up
+actions+=/expel_harm,if=chi.max-chi>=1&(energy.time_to_max<1|cooldown.serenity.remains<2|energy.time_to_max<4&cooldown.fists_of_fury.remains<1.5|cooldown.weapons_of_order.remains<2)&!buff.bonedust_brew.up
+actions+=/tiger_palm,target_if=min:debuff.mark_of_the_crane.remains,if=combo_strike&chi.max-chi>=2&(energy.time_to_max<1|cooldown.serenity.remains<2|energy.time_to_max<4&cooldown.fists_of_fury.remains<1.5|cooldown.weapons_of_order.remains<2)&!debuff.bonedust_brew_debuff.up
+actions+=/call_action_list,name=cd_sef,if=!talent.serenity
+actions+=/call_action_list,name=cd_serenity,if=talent.serenity
+actions+=/call_action_list,name=st,if=active_enemies<3
+actions+=/call_action_list,name=aoe,if=active_enemies>=3
+
+actions.aoe=whirling_dragon_punch
+actions.aoe+=/energizing_elixir,if=chi.max-chi>=2&energy.time_to_max>2|chi.max-chi>=4
+actions.aoe+=/spinning_crane_kick,if=combo_strike&(buff.dance_of_chiji.up|debuff.bonedust_brew_debuff.up)
+actions.aoe+=/fists_of_fury,if=energy.time_to_max>execute_time|chi.max-chi<=1
+actions.aoe+=/rising_sun_kick,target_if=min:debuff.mark_of_the_crane.remains,if=(talent.whirling_dragon_punch&cooldown.rising_sun_kick.duration>cooldown.whirling_dragon_punch.remains+4)&(cooldown.fists_of_fury.remains>3|chi>=5)
+actions.aoe+=/rushing_jade_wind,if=buff.rushing_jade_wind.down
+actions.aoe+=/expel_harm,if=chi.max-chi>=1
+actions.aoe+=/fist_of_the_white_tiger,target_if=min:debuff.mark_of_the_crane.remains,if=chi.max-chi>=3
+actions.aoe+=/chi_burst,if=chi.max-chi>=2
+actions.aoe+=/crackling_jade_lightning,if=buff.the_emperors_capacitor.stack>19&energy.time_to_max>execute_time-1&cooldown.fists_of_fury.remains>execute_time
+actions.aoe+=/tiger_palm,target_if=min:debuff.mark_of_the_crane.remains+(debuff.skyreach_exhaustion.up*20),if=chi.max-chi>=2&(!talent.hit_combo|combo_strike)
+actions.aoe+=/arcane_torrent,if=chi.max-chi>=1
+actions.aoe+=/spinning_crane_kick,if=combo_strike&(cooldown.bonedust_brew.remains>2|!covenant.necrolord)&(chi>=5|cooldown.fists_of_fury.remains>6|cooldown.fists_of_fury.remains>3&chi>=3&energy.time_to_50<1|energy.time_to_max<=(3+3*cooldown.fists_of_fury.remains<5)|buff.storm_earth_and_fire.up)
+actions.aoe+=/chi_wave,if=combo_strike
+actions.aoe+=/flying_serpent_kick,if=buff.bok_proc.down,interrupt=1
+actions.aoe+=/blackout_kick,target_if=min:debuff.mark_of_the_crane.remains,if=combo_strike&(buff.bok_proc.up|talent.hit_combo&prev_gcd.1.tiger_palm&chi=2&cooldown.fists_of_fury.remains<3|chi.max-chi<=1&prev_gcd.1.spinning_crane_kick&energy.time_to_max<3)
+
+actions.cd_sef=invoke_xuen_the_white_tiger,if=!variable.hold_xuen&(cooldown.rising_sun_kick.remains<2|!covenant.kyrian)&(!covenant.necrolord|cooldown.bonedust_brew.remains<2)|fight_remains<25
+actions.cd_sef+=/touch_of_death,if=fight_remains>(180-runeforge.fatal_touch*120)|buff.storm_earth_and_fire.down&pet.xuen_the_white_tiger.active&(!covenant.necrolord|buff.bonedust_brew.up)|(cooldown.invoke_xuen_the_white_tiger.remains>fight_remains)&buff.bonedust_brew.up|fight_remains<10
+actions.cd_sef+=/weapons_of_order,if=(raid_event.adds.in>45|raid_event.adds.up)&cooldown.rising_sun_kick.remains<execute_time&cooldown.invoke_xuen_the_white_tiger.remains>(20+20*runeforge.invokers_delight)|fight_remains<35
+actions.cd_sef+=/faeline_stomp,if=combo_strike&(raid_event.adds.in>10|raid_event.adds.up)
+actions.cd_sef+=/fallen_order,if=raid_event.adds.in>30|raid_event.adds.up
+actions.cd_sef+=/bonedust_brew,if=chi>=2&fight_remains>60&(cooldown.storm_earth_and_fire.charges>0|cooldown.storm_earth_and_fire.remains>10)&(pet.xuen_the_white_tiger.active|cooldown.invoke_xuen_the_white_tiger.remains>10|variable.hold_xuen)|(chi>=2&fight_remains<=60&(pet.xuen_the_White_tiger.active|cooldown.invoke_xuen_the_white_tiger.remains>fight_remains)&(cooldown.storm_earth_and_fire.charges>0|cooldown.storm_earth_and_fire.remains>fight_remains|buff.storm_earth_and_fire.up))|fight_remains<15
+actions.cd_sef+=/storm_earth_and_fire_fixate,if=conduit.coordinated_offensive.enabled
+actions.cd_sef+=/storm_earth_and_fire,if=cooldown.storm_earth_and_fire.charges=2|fight_remains<20|(raid_event.adds.remains>15|(!covenant.kyrian&!covenant.necrolord)&((raid_event.adds.in>cooldown.storm_earth_and_fire.full_recharge_time|!raid_event.adds.exists)&(cooldown.invoke_xuen_the_white_tiger.remains>cooldown.storm_earth_and_fire.full_recharge_time|variable.hold_xuen))&cooldown.fists_of_fury.remains<=9&chi>=2&cooldown.whirling_dragon_punch.remains<=12)
+actions.cd_sef+=/storm_earth_and_fire,if=covenant.kyrian&(buff.weapons_of_order.up|(fight_remains<cooldown.weapons_of_order.remains|cooldown.weapons_of_order.remains>cooldown.storm_earth_and_fire.full_recharge_time)&cooldown.fists_of_fury.remains<=9&chi>=2&cooldown.whirling_dragon_punch.remains<=12)
+actions.cd_sef+=/storm_earth_and_fire,if=covenant.necrolord&debuff.bonedust_brew_debuff.up&(pet.xuen_the_white_tiger.active|variable.hold_xuen|cooldown.invoke_xuen_the_white_tiger.remains>cooldown.storm_earth_and_fire.full_recharge_time|cooldown.invoke_xuen_the_white_tiger.remains>30)
+actions.cd_sef+=/use_item,name=inscrutable_quantum_device,if=pet.xuen_the_white_tiger.active|cooldown.invoke_xuen_the_white_tiger.remains>60&fight_remains>180|fight_remains<20
+actions.cd_sef+=/use_item,name=salvaged_fusion_amplifier,if=!variable.xuen_on_use_trinket|cooldown.invoke_xuen_the_white_tiger.remains>20&pet.xuen_the_white_tiger.remains<20|variable.hold_xuen
+actions.cd_sef+=/touch_of_karma,if=fight_remains>90|pet.xuen_the_white_tiger.active|variable.hold_xuen|fight_remains<16
+actions.cd_sef+=/blood_fury,if=cooldown.invoke_xuen_the_white_tiger.remains>30|variable.hold_xuen|fight_remains<20
+actions.cd_sef+=/berserking,if=cooldown.invoke_xuen_the_white_tiger.remains>30|variable.hold_xuen|fight_remains<15
+actions.cd_sef+=/lights_judgment
+actions.cd_sef+=/fireblood,if=cooldown.invoke_xuen_the_white_tiger.remains>30|variable.hold_xuen|fight_remains<10
+actions.cd_sef+=/ancestral_call,if=cooldown.invoke_xuen_the_white_tiger.remains>30|variable.hold_xuen|fight_remains<20
+actions.cd_sef+=/bag_of_tricks,if=buff.storm_earth_and_fire.down
+actions.cd_sef+=/fleshcraft,if=soulbind.pustule_eruption&debuff.bonedust_brew_debuff.down
+
+actions.cd_serenity=variable,name=serenity_burst,op=set,value=cooldown.serenity.remains<1|pet.xuen_the_white_tiger.active&cooldown.serenity.remains>30|fight_remains<20
+actions.cd_serenity+=/invoke_xuen_the_white_tiger,if=!variable.hold_xuen|fight_remains<25
+actions.cd_serenity+=/blood_fury,if=variable.serenity_burst
+actions.cd_serenity+=/berserking,if=variable.serenity_burst
+actions.cd_serenity+=/lights_judgment
+actions.cd_serenity+=/fireblood,if=variable.serenity_burst
+actions.cd_serenity+=/ancestral_call,if=variable.serenity_burst
+actions.cd_serenity+=/bag_of_tricks,if=variable.serenity_burst
+actions.cd_serenity+=/touch_of_death,if=fight_remains>(180-runeforge.fatal_touch*120)|pet.xuen_the_white_tiger.active&(!covenant.necrolord|buff.bonedust_brew.up)|(cooldown.invoke_xuen_the_white_tiger.remains>fight_remains)&buff.bonedust_brew.up|fight_remains<10
+actions.cd_serenity+=/touch_of_karma,if=fight_remains>90|pet.xuen_the_white_tiger.active|fight_remains<10
+actions.cd_serenity+=/weapons_of_order,if=cooldown.rising_sun_kick.remains<execute_time
+actions.cd_serenity+=/use_item,name=inscrutable_quantum_device,if=variable.serenity_burst|fight_remains<20
+actions.cd_serenity+=/use_item,name=salvaged_fusion_amplifier,if=!variable.xuen_on_use_trinket|cooldown.invoke_xuen_the_white_tiger.remains>20|variable.hold_xuen
+actions.cd_serenity+=/faeline_stomp
+actions.cd_serenity+=/fallen_order
+actions.cd_serenity+=/bonedust_brew,if=fight_remains<15|(chi>=2&(fight_remains>60&((cooldown.serenity.remains>10|buff.serenity.up|cooldown.serenity.up)&(pet.xuen_the_white_tiger.active|cooldown.invoke_xuen_the_white_tiger.remains>10|variable.hold_xuen)))|(fight_remains<=60&(pet.xuen_the_White_tiger.active|cooldown.invoke_xuen_the_white_tiger.remains>fight_remains)))
+actions.cd_serenity+=/serenity,if=cooldown.rising_sun_kick.remains<2|fight_remains<15
+actions.cd_serenity+=/bag_of_tricks
+actions.cd_serenity+=/fleshcraft,if=soulbind.pustule_eruption&buff.serenity.down&debuff.bonedust_brew_debuff.down
+
+actions.opener=fist_of_the_white_tiger,target_if=min:debuff.mark_of_the_crane.remains,if=chi.max-chi>=3
+actions.opener+=/expel_harm,if=talent.chi_burst.enabled&chi.max-chi>=3
+actions.opener+=/tiger_palm,target_if=min:debuff.mark_of_the_crane.remains+(debuff.skyreach_exhaustion.up*20),if=combo_strike&chi.max-chi>=2
+actions.opener+=/chi_wave,if=chi.max-chi=2
+actions.opener+=/expel_harm
+actions.opener+=/tiger_palm,target_if=min:debuff.mark_of_the_crane.remains+(debuff.skyreach_exhaustion.up*20),if=chi.max-chi>=2
+
+actions.serenity=fists_of_fury,if=buff.serenity.remains<1
+actions.serenity+=/spinning_crane_kick,if=combo_strike&(active_enemies>=3|active_enemies>1&!cooldown.rising_sun_kick.up)
+actions.serenity+=/rising_sun_kick,target_if=min:debuff.mark_of_the_crane.remains,if=combo_strike
+actions.serenity+=/fists_of_fury,if=active_enemies>=3
+actions.serenity+=/spinning_crane_kick,if=combo_strike&buff.dance_of_chiji.up
+actions.serenity+=/blackout_kick,target_if=min:debuff.mark_of_the_crane.remains,if=combo_strike&buff.weapons_of_order.up&cooldown.rising_sun_kick.remains>2
+actions.serenity+=/fists_of_fury,interrupt_if=!cooldown.rising_sun_kick.up
+actions.serenity+=/spinning_crane_kick,if=combo_strike&debuff.bonedust_brew_debuff.up
+actions.serenity+=/fist_of_the_white_tiger,target_if=min:debuff.mark_of_the_crane.remains,if=chi<3
+actions.serenity+=/blackout_kick,target_if=min:debuff.mark_of_the_crane.remains,if=combo_strike|!talent.hit_combo
+actions.serenity+=/spinning_crane_kick
+
+actions.st=whirling_dragon_punch,if=raid_event.adds.in>cooldown.whirling_dragon_punch.duration*0.8|raid_event.adds.up
+actions.st+=/energizing_elixir,if=chi.max-chi>=2&energy.time_to_max>3|chi.max-chi>=4&(energy.time_to_max>2|!prev_gcd.1.tiger_palm)
+actions.st+=/spinning_crane_kick,if=combo_strike&buff.dance_of_chiji.up&(raid_event.adds.in>buff.dance_of_chiji.remains-2|raid_event.adds.up)
+actions.st+=/rising_sun_kick,target_if=min:debuff.mark_of_the_crane.remains,if=cooldown.serenity.remains>1|!talent.serenity&(cooldown.weapons_of_order.remains>4|!covenant.kyrian)
+actions.st+=/fists_of_fury,if=(raid_event.adds.in>cooldown.fists_of_fury.duration*0.8|raid_event.adds.up)&(energy.time_to_max>execute_time-1|chi.max-chi<=1|buff.storm_earth_and_fire.remains<execute_time+1)|fight_remains<execute_time+1|debuff.bonedust_brew_debuff.up
+actions.st+=/crackling_jade_lightning,if=buff.the_emperors_capacitor.stack>19&energy.time_to_max>execute_time-1&cooldown.rising_sun_kick.remains>execute_time|buff.the_emperors_capacitor.stack>14&(cooldown.serenity.remains<5&talent.serenity|cooldown.weapons_of_order.remains<5&covenant.kyrian|fight_remains<5)
+actions.st+=/rushing_jade_wind,if=buff.rushing_jade_wind.down&active_enemies>1
+actions.st+=/fist_of_the_white_tiger,target_if=min:debuff.mark_of_the_crane.remains,if=chi<3
+actions.st+=/expel_harm,if=chi.max-chi>=1
+actions.st+=/chi_burst,if=chi.max-chi>=1&active_enemies=1&raid_event.adds.in>20|chi.max-chi>=2&active_enemies>=2
+actions.st+=/chi_wave
+actions.st+=/tiger_palm,target_if=min:debuff.mark_of_the_crane.remains+(debuff.skyreach_exhaustion.up*20),if=combo_strike&chi.max-chi>=2&buff.storm_earth_and_fire.down
+actions.st+=/spinning_crane_kick,if=buff.chi_energy.stack>30-5*active_enemies&buff.storm_earth_and_fire.down&(cooldown.rising_sun_kick.remains>2&cooldown.fists_of_fury.remains>2|cooldown.rising_sun_kick.remains<3&cooldown.fists_of_fury.remains>3&chi>3|cooldown.rising_sun_kick.remains>3&cooldown.fists_of_fury.remains<3&chi>4|chi.max-chi<=1&energy.time_to_max<2)|buff.chi_energy.stack>10&fight_remains<7
+actions.st+=/blackout_kick,target_if=min:debuff.mark_of_the_crane.remains,if=combo_strike&(talent.serenity&cooldown.serenity.remains<3|cooldown.rising_sun_kick.remains>1&cooldown.fists_of_fury.remains>1|cooldown.rising_sun_kick.remains<3&cooldown.fists_of_fury.remains>3&chi>2|cooldown.rising_sun_kick.remains>3&cooldown.fists_of_fury.remains<3&chi>3|chi>5|buff.bok_proc.up)
+actions.st+=/tiger_palm,target_if=min:debuff.mark_of_the_crane.remains+(debuff.skyreach_exhaustion.up*20),if=combo_strike&chi.max-chi>=2
+actions.st+=/arcane_torrent,if=chi.max-chi>=1
+actions.st+=/flying_serpent_kick,interrupt=1
+actions.st+=/blackout_kick,target_if=min:debuff.mark_of_the_crane.remains,if=combo_strike&cooldown.fists_of_fury.remains<3&chi=2&prev_gcd.1.tiger_palm&energy.time_to_50<1
+actions.st+=/blackout_kick,target_if=min:debuff.mark_of_the_crane.remains,if=combo_strike&energy.time_to_max<2&(chi.max-chi<=1|prev_gcd.1.tiger_palm)
+
+actions.weapons_of_order=variable,name=blackout_kick_needed,op=set,value=buff.weapons_of_order_ww.remains&(cooldown.rising_sun_kick.remains>buff.weapons_of_order_ww.remains&buff.weapons_of_order_ww.remains<2.1|cooldown.rising_sun_kick.remains-buff.weapons_of_order_ww.remains>1.9&buff.weapons_of_order_ww.remains<4.1|buff.bloodlust.up&buff.invokers_delight.up&buff.invokers_delight.remains<buff.weapons_of_order_ww.remains)
+actions.weapons_of_order+=/call_action_list,name=cd_sef,if=!talent.serenity
+actions.weapons_of_order+=/call_action_list,name=cd_serenity,if=talent.serenity
+actions.weapons_of_order+=/energizing_elixir,if=chi.max-chi>=2&energy.time_to_max>3
+actions.weapons_of_order+=/rising_sun_kick,target_if=min:debuff.mark_of_the_crane.remains
+actions.weapons_of_order+=/fists_of_fury,if=active_enemies>=2&buff.weapons_of_order_ww.remains<1
+actions.weapons_of_order+=/whirling_dragon_punch,if=active_enemies>=2
+actions.weapons_of_order+=/spinning_crane_kick,if=combo_strike&active_enemies>=3&buff.weapons_of_order_ww.up
+actions.weapons_of_order+=/blackout_kick,target_if=min:debuff.mark_of_the_crane.remains,if=combo_strike&active_enemies<=2&variable.blackout_kick_needed
+actions.weapons_of_order+=/spinning_crane_kick,if=combo_strike&buff.dance_of_chiji.up
+actions.weapons_of_order+=/expel_harm,if=chi=0&buff.weapons_of_order_ww.remains<4
+actions.weapons_of_order+=/fist_of_the_white_tiger,target_if=min:debuff.mark_of_the_crane.remains,if=chi=0&buff.weapons_of_order_ww.remains<4
+actions.weapons_of_order+=/whirling_dragon_punch
+actions.weapons_of_order+=/tiger_palm,target_if=min:debuff.mark_of_the_crane.remains+(debuff.skyreach_exhaustion.up*20),if=chi=0&buff.weapons_of_order_ww.remains<4
+actions.weapons_of_order+=/fists_of_fury,interrupt=1,if=buff.storm_earth_and_fire.up&raid_event.adds.in>cooldown.fists_of_fury.duration*0.6
+actions.weapons_of_order+=/spinning_crane_kick,if=buff.chi_energy.stack>30-5*active_enemies
+actions.weapons_of_order+=/fist_of_the_white_tiger,target_if=min:debuff.mark_of_the_crane.remains,if=chi<3
+actions.weapons_of_order+=/expel_harm,if=chi.max-chi>=1
+actions.weapons_of_order+=/chi_burst,if=chi.max-chi>=(1+active_enemies>1)
+actions.weapons_of_order+=/tiger_palm,target_if=min:debuff.mark_of_the_crane.remains+(debuff.skyreach_exhaustion.up*20),if=(!talent.hit_combo|combo_strike)&chi.max-chi>=2
+actions.weapons_of_order+=/blackout_kick,target_if=min:debuff.mark_of_the_crane.remains,if=active_enemies<=3&chi>=3|buff.weapons_of_order_ww.up
+actions.weapons_of_order+=/chi_wave
+actions.weapons_of_order+=/flying_serpent_kick,interrupt=1
+
+head=cap_of_writhing_malevolence,id=186292,bonus_id=7187/1498,gem_id=187318
+neck=azurevenom_choker,id=180115,bonus_id=6536/1566/6646/6935,gem_id=173129
+shoulders=spaulders_of_the_crooked_confidant,id=186336,bonus_id=7187/1498,gem_id=187315
+back=blighted_margraves_cloak,id=178755,bonus_id=6536/1566/6646,enchant=soul_vitality
+chest=witherheart_studded_breastplate,id=186334,bonus_id=7187/1498,gem_id=187312,enchant=eternal_skirmish
+wrists=bands_of_the_undergrowth,id=178702,bonus_id=6536/1566/6646/6935,gem_id=173129
+hands=loyal_kvaldirs_handwraps,id=186295,bonus_id=7187/1498,gem_id=187313
+waist=girdle_of_shattered_dreams,id=178805,bonus_id=6536/1566/6646/6935,gem_id=173129
+legs=elite_aranakk_breeches,id=186331,bonus_id=7187/1498
+feet=daschlas_defiant_treads,id=186299,bonus_id=7187/1498,gem_id=187314,enchant=eternal_agility
+finger1=shadowghast_ring,id=178926,bonus_id=7726/1559/6650/6647/6935,gem_id=173129,enchant=tenet_of_versatility
+finger2=tarnished_insignia_of_quelthalas,id=186377,bonus_id=7187/1498/6935,gem_id=173129,enchant=tenet_of_versatility
+trinket1=inscrutable_quantum_device,id=179350,bonus_id=6536/1566/6646
+trinket2=salvaged_fusion_amplifier,id=186432,bonus_id=7187/1498
+main_hand=cruciform_veinripper,id=186388,bonus_id=7187/1498,enchant=sinful_revelation
+off_hand=cruciform_veinripper,id=186388,bonus_id=7187/1498,enchant=celestial_guidance
+
+# Gear Summary
+# gear_ilvl=254.38
+# gear_agility=1094
+# gear_stamina=2109
+# gear_attack_power=40
+# gear_crit_rating=1037
+# gear_haste_rating=255
+# gear_mastery_rating=50
+# gear_versatility_rating=727
+# gear_armor=713

--- a/profiles/generators/Tier27/T27_Generate_Monk.simc
+++ b/profiles/generators/Tier27/T27_Generate_Monk.simc
@@ -121,3 +121,34 @@ main_hand=cruciform_veinripper,id=186388,bonus_id=7187/1498,enchant=sinful_revel
 off_hand=cruciform_veinripper,id=186388,bonus_id=7187/1498,enchant=celestial_guidance
 
 save=T27_Monk_Windwalker_Necrolord.simc
+
+# Venthyr Windwalker
+monk="T27_Monk_Windwalker_Venthyr"
+level=60
+race=mechagnome
+spec=windwalker
+role=attack
+position=back
+talents=2020012
+covenant=venthyr
+soulbind=theotar_the_mad_duke:9,soothing_shade/Imbued_reflections:9:1/coordinated_offensive:9:1/token_of_appreciation/xuens_bond:9:1/its_always_tea_time/party_favors
+renown=80
+
+head=cap_of_writhing_malevolence,id=186292,bonus_id=7187/1498,gem_id=187318
+neck=azurevenom_choker,id=180115,bonus_id=6536/1566/6646/6935,gem_id=173129
+shoulders=spaulders_of_the_crooked_confidant,id=186336,bonus_id=7187/1498,gem_id=187315
+back=blighted_margraves_cloak,id=178755,bonus_id=6536/1566/6646,enchant=soul_vitality
+chest=witherheart_studded_breastplate,id=186334,bonus_id=7187/1498,gem_id=187312,enchant=eternal_skirmish
+wrists=bands_of_the_undergrowth,id=178702,bonus_id=6536/1566/6646/6935,gem_id=173129
+hands=loyal_kvaldirs_handwraps,id=186295,bonus_id=7187/1498,gem_id=187313
+waist=girdle_of_shattered_dreams,id=178805,bonus_id=6536/1566/6646/6935,gem_id=173129
+legs=elite_aranakk_breeches,id=186331,bonus_id=7187/1498
+feet=daschlas_defiant_treads,id=186299,bonus_id=7187/1498,gem_id=187314,enchant=eternal_agility
+finger1=shadowghast_ring,id=178926,bonus_id=7726/1559/6650/6647/6935,gem_id=173129,enchant=tenet_of_versatility
+finger2=tarnished_insignia_of_quelthalas,id=186377,bonus_id=7187/1498/6935,gem_id=173129,enchant=tenet_of_versatility
+trinket1=inscrutable_quantum_device,id=179350,bonus_id=6536/1566/6646
+trinket2=salvaged_fusion_amplifier,id=186432,bonus_id=7187/1498
+main_hand=cruciform_veinripper,id=186388,bonus_id=7187/1498,enchant=sinful_revelation
+off_hand=cruciform_veinripper,id=186388,bonus_id=7187/1498,enchant=celestial_guidance
+
+save=T27_Monk_Windwalker_Venthyr.simc

--- a/profiles/generators/Tier27/T27_Generate_Monk.simc
+++ b/profiles/generators/Tier27/T27_Generate_Monk.simc
@@ -131,7 +131,7 @@ role=attack
 position=back
 talents=2020012
 covenant=venthyr
-soulbind=theotar_the_mad_duke:9,soothing_shade/Imbued_reflections:9:1/coordinated_offensive:9:1/token_of_appreciation/xuens_bond:9:1/its_always_tea_time/party_favors
+soulbind=theotar_the_mad_duke:9,soothing_shade/coordinated_offensive:9:1/wasteland_propriety/imbued_reflections:9:1/its_always_tea_time/party_favors
 renown=80
 
 head=cap_of_writhing_malevolence,id=186292,bonus_id=7187/1498,gem_id=187318
@@ -148,7 +148,7 @@ finger1=shadowghast_ring,id=178926,bonus_id=7726/1559/6650/6647/6935,gem_id=1731
 finger2=tarnished_insignia_of_quelthalas,id=186377,bonus_id=7187/1498/6935,gem_id=173129,enchant=tenet_of_versatility
 trinket1=inscrutable_quantum_device,id=179350,bonus_id=6536/1566/6646
 trinket2=salvaged_fusion_amplifier,id=186432,bonus_id=7187/1498
-main_hand=cruciform_veinripper,id=186388,bonus_id=7187/1498,enchant=sinful_revelation
+main_hand=cruciform_veinripper,id=186388,bonus_id=7187/1498,enchant=celestial_guidance
 off_hand=cruciform_veinripper,id=186388,bonus_id=7187/1498,enchant=celestial_guidance
 
 save=T27_Monk_Windwalker_Venthyr.simc


### PR DESCRIPTION
I increased the priority of hammer of wrath when in ashen with VM or MP equipped, and increased vanq hammer prio. I also added a conditional to vanq hammer to only cast with seraphim if you have DBG and seraphim talented.